### PR TITLE
Claude agent setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md for babylon_data_loader
+
+This guide provides instructions for building, running, testing, and developing within the `babylon_data_loader` repository.
+
+## Commands
+
+### Build and Clean
+- **Build application**: `make build` (creates executable in `out/data-loader`)
+- **Clean build artifacts**: `make clean`
+- **Tidy Go modules**: `make tidy`
+- **Vendoring dependencies**: `make vendor`
+
+### Run and Ingestion
+- **Run data ingestion**: `make run` or `make run-ingest`
+- **Generate synthetic CSV data**: `make run-generate` (creates synthetic transaction CSVs in `tmp/`)
+- **Generate and persist synthetic data to Mongo**: `make run-generate-mongo`
+
+### Test and Quality
+- **All Quality Checks (Lint, Format, Vet)**: `make check-quality`
+- **Run unit tests**: `make unit-test`
+- **Run tests with JSON output (CI)**: `make test-ci`
+- **Show test coverage in HTML**: `make coverage`
+- **Format code**: `make fmt` (runs `goimports` and `gofumpt`)
+- **Lint code**: `make lint` (runs `golangci-lint`)
+- **Vet code**: `make vet` (runs `go vet`)
+
+---
+
+## Security & PII Guidelines
+
+> [!IMPORTANT]
+> The `babylon` data lake processes Personally Identifiable Information (PII) including Account IDs, balance amounts, and transaction descriptions. Follow these guidelines strictly:
+
+1. **No Real PII**: Do not hardcode, commit, or check in real datasets, transaction records, or any production database dumps to this repository.
+2. **Log Safety**: Never include real PII (such as account details, names, sensitive description fields, or exact balances) in logs. Keep `slog` log fields generic and aggregate.
+3. **Use Synthetic Data for Dev/Test**: Always use the built-in synthetic generators to produce non-sensitive mock datasets for testing and local environment setups:
+   - To generate local CSVs for testing: `go run main.go generate-synthetic-data --rows 100 --dir tmp/synthetic`
+   - To populate local MongoDB: `go run main.go generate-synthetic-data --rows 100 --persist-to-mongo`
+4. **Environment Variables**: Never hardcode credentials. Ensure Mongo/DB configurations are fetched from the environment:
+   - `MONGO_HOST`
+   - `MONGO_USER`
+   - `MONGO_PASSWORD`
+   - `MONGO_URI`
+
+---
+
+## Code Guidelines & Formatting
+
+- **Formatting**: We enforce strict formatting rules. Always run `make fmt` before committing.
+- **Function Comments**: Write clear comments on exported package functions and structs.
+- **Inline Comments**: Use inline comments sparsely and only when describing complex business logic or edge cases.
+- **Testing**: Always run `make unit-test` after making changes to verify correctness.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This guide provides instructions for building, running, testing, and developing within the `babylon_data_loader` repository.
 
+## Documentation & Agent Harness
+
+This project contains a comprehensive agent documentation harness under the [docs/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs) folder. Refer to these files for deeper context:
+- **[Harness Index (README)](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/README.md)**: Main entry point for project docs.
+- **[Agent Personas](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/agent_personas.md)**: Specific instructions, prompts, and expectations for Software Engineering and DevOps agent roles.
+- **[Architecture & Data Flow](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/architecture.md)**: Details on packages, data pathways, and components.
+- **[PII & Security Guidelines](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/pii_handling.md)**: Rules for preserving PII confidentiality, logging securely, and generating mock datasets.
+- **[Development & Testing Guide](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/development.md)**: Prerequisites, formatting tools, linting, and troubleshooting.
+
+---
+
 ## Commands
 
 ### Build and Clean

--- a/README.md
+++ b/README.md
@@ -1,43 +1,78 @@
-## Babylon Data Loader
-Load data for babylon.
+# Babylon Data Loader
 
-## Prerequisites
-- `go 1.24.4`
+The `babylon_data_loader` is a Go-based ingestion tool designed to load transactional datasets into the `babylon` data lake (backed by MongoDB). It features a robust CSV parsing engine, flexible environment configurations, and an integrated synthetic data pipeline to facilitate local development and testing without exposing sensitive data.
 
-- `GNU Make 3.81`
+---
 
-- `mongodb` [driver for `go`](http://github.com/mongodb/mongo-go-driver)
+## Quick Start
 
-## Building and Running
-`make all` will run linters, run unit tests, and build a dist.
+### 1. Prerequisites
+- **Go**: `1.26` or higher
+- **GNU Make**: `3.81` or higher
+- **MongoDB**: A running local or remote instance
 
-### Executable Artifacts
-By default, executable artifacts are created in `out/` as a result of a `make build` command.
+### 2. Configure Environment
+Set the required environment variables (defaults are set in the [Makefile](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/makefile)):
+```bash
+export MONGO_HOST=localhost
+export MONGO_USER=<MONGO_USER>
+export MONGO_PASSWORD=<MONGO_PASSWORD>
+```
 
-## Upgrading Go Environment
+### 3. Build & Run
+Run all checks (linting, tests, build):
+```bash
+make all
+```
+
+Populate your local MongoDB instance with 100 rows of synthetic data:
+```bash
+make run-generate-mongo
+```
+
+Run the main ingestion pipeline:
+```bash
+make run-ingest
+```
+
+---
+
+## Documentation & Agent Harness
+
+To support both human developers and AI coding agents, this repository maintains a structured documentation harness in the [docs/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs) directory:
+
+- **[System Architecture](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/architecture.md)**: Diagrams and descriptions of the data loader packages and lifecycle.
+- **[PII & Security Guidelines](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/pii_handling.md)**: Rules on logging precautions, security credentials, and synthetic data utility.
+- **[Development & Testing Guide](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/development.md)**: Local setups, testing commands, and troubleshooting guides.
+- **[Agent Personas](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/agent_personas.md)**: System prompt files and execution scopes for specialized agent developers.
+
+For a summary of quick command flags, refer to **[CLAUDE.md](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/CLAUDE.md)**.
+
+---
+
+## Security Notice: PII Handling
+
+> [!WARNING]
+> This data lake processes Personally Identifiable Information (PII) like Account IDs and transaction balances. Do **not** commit real database dumps, raw transaction CSV files, or API credentials to this repository. Keep all log statements free of raw PII values.
+
+---
+
+## Upgrading the Go Environment
 
 To upgrade the Go environment for this project, follow these steps:
 
-1.  **Update `go.mod`:**
-    Modify the `go.mod` file to reflect the desired Go version. For example, to upgrade to Go 1.26, change the line `go 1.24.4` to `go 1.26`.
-
-2.  **Clean and Tidy Modules:**
-    After updating `go.mod`, run the following commands to clean the module cache and tidy up dependencies:
-    ```bash
-    go clean -modcache
-    go mod tidy
-    ```
-
-3.  **Upgrade `golangci-lint`:**
-    If you encounter issues with `golangci-lint` after upgrading Go (e.g., "Go language version used to build golangci-lint is lower than the targeted Go version"), you might need to upgrade `golangci-lint`.
-    If installed via Homebrew (macOS), run:
-    ```bash
-    brew upgrade golangci-lint
-    ```
-    For other installation methods, refer to the `golangci-lint` documentation.
-
-4.  **Verify the Upgrade:**
-    After performing the above steps, run `make` to ensure all linters, tests, and builds pass with the new Go version.
-    ```bash
-    make
-    ```
+1. **Update `go.mod`**:
+   Modify the `go.mod` file to reflect the desired Go version (e.g., change `go 1.26` to `go 1.27`).
+2. **Clean and Tidy Modules**:
+   ```bash
+   go clean -modcache
+   go mod tidy
+   ```
+3. **Upgrade `golangci-lint`**:
+   If you encounter issues with `golangci-lint` after upgrading Go, you might need to upgrade the linter.
+   - On macOS via Homebrew: `brew upgrade golangci-lint`
+   - For other OS/install methods, consult the official `golangci-lint` documentation.
+4. **Verify changes**:
+   ```bash
+   make
+   ```

--- a/aget.devops.md
+++ b/aget.devops.md
@@ -1,9 +1,0 @@
-# System Prompt
-You are an expert dev-ops engineer. You specialize in Github Action CI/CD pipelines.
-
-# User Prompt
-Please wait for user input.
-
-## CI
-The CI for this project is Github Actions defined in `./github`.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Agent Document Harness
+
+This directory contains the developer and AI agent documentation harness for `babylon_data_loader`. This harness guides AI agents and developers on project structure, agent personas, architectures, and guidelines.
+
+## Harness Index
+
+- **[Agent Personas](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/agent_personas.md)**: System prompts and instructions for specialized agent roles (Software Engineering, DevOps).
+- **[Architecture & Data Flow](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/architecture.md)**: Technical breakdown of the ingest engine, CSV parser, MongoDB storage layer, and synthetic data generator.
+- **[PII & Security Guidelines](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/pii_handling.md)**: Deep dive into the PII policies, synthetic data usage, and security parameters of the `babylon` data lake.
+- **[Local Development & Testing Guide](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/docs/development.md)**: Guide on how to set up, test, configure, and troubleshoot the codebase locally.

--- a/docs/agent_personas.md
+++ b/docs/agent_personas.md
@@ -1,0 +1,37 @@
+# Agent Personas
+
+This file defines the system prompts and expectations for various AI agent roles that work on this codebase.
+
+---
+
+## 1. Software Engineer Agent
+**Target Role**: General code modification, feature implementation, and bug fixing.
+
+### System Prompt
+```markdown
+You are an expert software engineer, who specializes in Go, MongoDB, Data Pipelines, and RAG.
+
+Key Guidelines:
+1. Comments: Add clear comments to functions and structs. Use inline comments sparsely and only when necessary.
+2. Verification: Always test after making changes.
+```
+
+### Tasks & Commands
+- **Building**: Run `make` to lint, test, and build the app.
+- **Testing**: Run `make unit-test` to execute tests.
+- **Linting**: Always lint with `make lint`.
+- **Executing**: Run the app with `make run` (or `make run-ingest`). By default, it will attempt to process any data in the `unprocessed` directory.
+
+---
+
+## 2. DevOps & CI/CD Agent
+**Target Role**: Infrastructure, workflow, and action runner updates.
+
+### System Prompt
+```markdown
+You are an expert dev-ops engineer. You specialize in Github Action CI/CD pipelines.
+```
+
+### Tasks & Commands
+- **CI Configuration**: The CI for this project is powered by Github Actions, defined in the [.github](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/.github) directory.
+- **Monitoring CI**: Run `./monitor-ci.sh` to check quality and test runs locally mirroring the CI check.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,34 @@
+# Architecture & Data Flow
+
+This document details the system design, components, and data flow of the `babylon_data_loader`.
+
+## System Architecture
+
+```mermaid
+graph TD
+    A[unprocessed/ CSV Files] -->|Ingest Command| B[CSV Parser]
+    B -->|Parse Records| C[Ingest Sink]
+    C -->|Extract Metadata| D[Generic Extractor]
+    C -->|Persist| E[Mongo Repository]
+    E -->|Write| F[(MongoDB - Datalake DB)]
+    G[Synthetic Generator] -->|Generate Command| A
+    G -->|Persist Command| F
+```
+
+## Core Components
+
+1. **Entrypoint ([main.go](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/main.go))**: Handles command-line arguments and routes requests to either the synthetic data generator or the data ingestion process.
+2. **Context & Logging ([appcontext/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/appcontext))**: Standardizes how context propagates with `slog` logger instances attached.
+3. **Configuration ([config/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/config))**: Loads database connection details, timeouts, and file paths.
+4. **CSV Parser ([csv/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/csv))**: Flexibly parses CSV data with dynamic header mapping.
+5. **Datalake Engine ([datalake/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/datalake))**: Represents core business entities, interfaces, and extraction services (like [datasource/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/datalake/datasource)).
+6. **Ingest Sink ([ingest/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/ingest))**: Coordinates the flow of reading unprocessed files, invoking the CSV parser, and invoking the repository to save records.
+7. **Storage Repository ([storage/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/storage))**: Interacts with MongoDB. Implements bulk upsert actions.
+8. **Synthetic Generator ([synthetic/](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/synthetic))**: Generates deterministic/random transaction mock datasets to avoid using real PII.
+
+## Data Ingestion Flow
+
+1. The user/system executes `make run-ingest` (which runs `data-loader ingest`).
+2. The `ingest.Sink` scans the configured directory (e.g., `unprocessed/`) for CSV files.
+3. For each file, the `csv.Parser` maps columns (Account ID, Balance, Posting Date, Details, etc.) to structured structures.
+4. The database layer performs a bulk upsert of these records into MongoDB under the target collections (e.g., `transactions_<datasource>`).

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,8 +7,8 @@ This document describes how to build, test, and troubleshoot the `babylon_data_l
 - **Go**: Version 1.26 (or matching version specified in [go.mod](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/go.mod))
 - **MongoDB**: A running MongoDB instance. Default credentials and hosts can be overridden via env variables:
   - `MONGO_HOST=localhost`
-  - `MONGO_USER=babylon`
-  - `MONGO_PASSWORD=babylonpass`
+  - `MONGO_USER=<MONGO_USER>`
+  - `MONGO_PASSWORD=<MONGO_PASSWORD>`
 - **GNU Make**: Used to run commands easily.
 
 ## Development Tasks

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,48 @@
+# Local Development & Testing Guide
+
+This document describes how to build, test, and troubleshoot the `babylon_data_loader` locally.
+
+## Prerequisite Tools
+
+- **Go**: Version 1.26 (or matching version specified in [go.mod](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/go.mod))
+- **MongoDB**: A running MongoDB instance. Default credentials and hosts can be overridden via env variables:
+  - `MONGO_HOST=localhost`
+  - `MONGO_USER=babylon`
+  - `MONGO_PASSWORD=babylonpass`
+- **GNU Make**: Used to run commands easily.
+
+## Development Tasks
+
+### 1. Code Formatting
+Before committing, always run the formatters to check formatting rules:
+```bash
+make fmt
+```
+This runs `goimports` and `gofumpt` to format code according to our Go style standards.
+
+### 2. Linting & Vet
+To verify package imports, styling rules, and common programming errors:
+```bash
+make lint
+make vet
+```
+Both are included in the quality checklist:
+```bash
+make check-quality
+```
+
+### 3. Testing
+To run all unit tests:
+```bash
+make unit-test
+```
+
+To see test coverage as an interactive webpage:
+```bash
+make coverage
+```
+
+## Troubleshooting
+
+- **MongoDB connection issues**: If you encounter connection errors during ingestion, verify the `MONGO_URI` environment variable or check that your local MongoDB container is running.
+- **Go version conflicts**: If you upgraded your machine's Go compiler and run into linter issues, check the [README.md](file:///Users/aponte/personal_workspace/babylon-2.0/babylon_data_loader/README.md) instructions on upgrading the Go environment.

--- a/docs/pii_handling.md
+++ b/docs/pii_handling.md
@@ -1,0 +1,34 @@
+# PII & Security Guidelines
+
+The `babylon` data lake stores Personally Identifiable Information (PII) to support data loader requirements. This document outlines rules and practices to maintain data security and avoid leaks.
+
+## Identifying PII in Babylon
+
+The following fields in the transaction schema are considered PII or sensitive:
+- **AccountID**: Internal bank/account identifiers.
+- **Balance / Amount**: Financial details which must be treated with high confidentiality.
+- **Description / Details**: May contain names, vendor descriptors, or other tracking tokens containing personal information.
+
+## Safety Rules for Developers & Agents
+
+### 1. No Production Data in the Repository
+Never copy, download, or commit raw transaction records, CSVs, or MongoDB exports from a production or staging environment into the repository. 
+
+### 2. Log Scrubbing
+Ensure logs do not print actual PII values:
+- Use structured log fields in `slog`.
+- Do not output entire records or transaction bodies in `slog.ErrorContext` or `slog.InfoContext`. Instead, log metadata like row count, collection names, file names, or truncated non-sensitive ID formats.
+
+### 3. Generate Mock Data Locally
+Utilize the synthetic data pipeline for all manual and automated testing. 
+
+- To output a synthetic CSV:
+  ```bash
+  make run-generate
+  ```
+- To populate local MongoDB with synthetic data:
+  ```bash
+  make run-generate-mongo
+  ```
+
+This ensures zero risk of leakages while maintaining representative schemas and volumes.

--- a/docs/prompts/CLAUDE-PROMPT.md
+++ b/docs/prompts/CLAUDE-PROMPT.md
@@ -1,0 +1,12 @@
+# System Prompt
+You are an expert AI Software Engineer. You specialize in LLMs, but you also have deep knowledge of Machine Learning.
+
+
+# User Prompt
+Create an initial `CLAUDE.md` file for `babylon_data_loader`.
+
+
+## Key Points
+- This project stores code for the `babylon` data lake.
+- The data lake has PII.
+

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@
 
 # Export environment variables to be available in shell commands
 export MONGO_HOST ?= localhost
-export MONGO_USER ?= babylon
-export MONGO_PASSWORD ?= babylonpass
+export MONGO_USER ?= <MONGO_USER>
+export MONGO_PASSWORD ?= <MONGO_PASSWORD>
 
 export GO111MODULE=on
 # update app name. this is the name of binary

--- a/vendor/github.com/golang/snappy/decode_asm.go
+++ b/vendor/github.com/golang/snappy/decode_asm.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !appengine && gc && !noasm && (amd64 || arm64)
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/vendor/github.com/golang/snappy/decode_asm.go
+++ b/vendor/github.com/golang/snappy/decode_asm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !appengine && gc && !noasm && (amd64 || arm64)
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/vendor/github.com/golang/snappy/decode_other.go
+++ b/vendor/github.com/golang/snappy/decode_other.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (!amd64 && !arm64) || appengine || !gc || noasm
 // +build !amd64,!arm64 appengine !gc noasm
 
 package snappy

--- a/vendor/github.com/golang/snappy/decode_other.go
+++ b/vendor/github.com/golang/snappy/decode_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (!amd64 && !arm64) || appengine || !gc || noasm
 // +build !amd64,!arm64 appengine !gc noasm
 
 package snappy

--- a/vendor/github.com/golang/snappy/encode_asm.go
+++ b/vendor/github.com/golang/snappy/encode_asm.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !appengine && gc && !noasm && (amd64 || arm64)
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/vendor/github.com/golang/snappy/encode_asm.go
+++ b/vendor/github.com/golang/snappy/encode_asm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !appengine && gc && !noasm && (amd64 || arm64)
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/vendor/github.com/golang/snappy/encode_other.go
+++ b/vendor/github.com/golang/snappy/encode_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (!amd64 && !arm64) || appengine || !gc || noasm
 // +build !amd64,!arm64 appengine !gc noasm
 
 package snappy
@@ -20,6 +21,7 @@ func load64(b []byte, i int) uint64 {
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 //
 // It assumes that:
+//
 //	dst is long enough to hold the encoded bytes
 //	1 <= len(lit) && len(lit) <= 65536
 func emitLiteral(dst, lit []byte) int {
@@ -44,6 +46,7 @@ func emitLiteral(dst, lit []byte) int {
 // emitCopy writes a copy chunk and returns the number of bytes written.
 //
 // It assumes that:
+//
 //	dst is long enough to hold the encoded bytes
 //	1 <= offset && offset <= 65535
 //	4 <= length && length <= 65535
@@ -91,6 +94,7 @@ func emitCopy(dst []byte, offset, length int) int {
 // src[i:i+k-j] and src[j:k] have the same contents.
 //
 // It assumes that:
+//
 //	0 <= i && i < j && j <= len(src)
 func extendMatch(src []byte, i, j int) int {
 	for ; j < len(src) && src[i] == src[j]; i, j = i+1, j+1 {
@@ -107,8 +111,9 @@ func hash(u, shift uint32) uint32 {
 // been written.
 //
 // It also assumes that:
+//
 //	len(dst) >= MaxEncodedLen(len(src)) &&
-// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+//	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlock(dst, src []byte) (d int) {
 	// Initialize the hash table. Its size ranges from 1<<8 to 1<<14 inclusive.
 	// The table element type is uint16, as s < sLimit and sLimit < len(src)

--- a/vendor/github.com/golang/snappy/encode_other.go
+++ b/vendor/github.com/golang/snappy/encode_other.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (!amd64 && !arm64) || appengine || !gc || noasm
 // +build !amd64,!arm64 appengine !gc noasm
 
 package snappy
@@ -21,7 +20,6 @@ func load64(b []byte, i int) uint64 {
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 //
 // It assumes that:
-//
 //	dst is long enough to hold the encoded bytes
 //	1 <= len(lit) && len(lit) <= 65536
 func emitLiteral(dst, lit []byte) int {
@@ -46,7 +44,6 @@ func emitLiteral(dst, lit []byte) int {
 // emitCopy writes a copy chunk and returns the number of bytes written.
 //
 // It assumes that:
-//
 //	dst is long enough to hold the encoded bytes
 //	1 <= offset && offset <= 65535
 //	4 <= length && length <= 65535
@@ -94,7 +91,6 @@ func emitCopy(dst []byte, offset, length int) int {
 // src[i:i+k-j] and src[j:k] have the same contents.
 //
 // It assumes that:
-//
 //	0 <= i && i < j && j <= len(src)
 func extendMatch(src []byte, i, j int) int {
 	for ; j < len(src) && src[i] == src[j]; i, j = i+1, j+1 {
@@ -111,9 +107,8 @@ func hash(u, shift uint32) uint32 {
 // been written.
 //
 // It also assumes that:
-//
 //	len(dst) >= MaxEncodedLen(len(src)) &&
-//	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlock(dst, src []byte) (d int) {
 	// Initialize the hash table. Its size ranges from 1<<8 to 1<<14 inclusive.
 	// The table element type is uint16, as s < sLimit and sLimit < len(src)

--- a/vendor/github.com/xdg-go/pbkdf2/pbkdf2.go
+++ b/vendor/github.com/xdg-go/pbkdf2/pbkdf2.go
@@ -31,7 +31,7 @@ import (
 // constructor for a hashing function.  For example, for a 32-byte key using
 // SHA-256:
 //
-//  key := Key([]byte("trustNo1"), salt, 10000, 32, sha256.New)
+//	key := Key([]byte("trustNo1"), salt, 10000, 32, sha256.New)
 func Key(password, salt []byte, iterCount, keyLen int, h func() hash.Hash) []byte {
 	prf := hmac.New(h, password)
 	hLen := prf.Size()

--- a/vendor/github.com/xdg-go/pbkdf2/pbkdf2.go
+++ b/vendor/github.com/xdg-go/pbkdf2/pbkdf2.go
@@ -31,7 +31,7 @@ import (
 // constructor for a hashing function.  For example, for a 32-byte key using
 // SHA-256:
 //
-//	key := Key([]byte("trustNo1"), salt, 10000, 32, sha256.New)
+//  key := Key([]byte("trustNo1"), salt, 10000, 32, sha256.New)
 func Key(password, salt []byte, iterCount, keyLen int, h func() hash.Hash) []byte {
 	prf := hmac.New(h, password)
 	hLen := prf.Size()

--- a/vendor/github.com/xdg-go/scram/doc.go
+++ b/vendor/github.com/xdg-go/scram/doc.go
@@ -8,18 +8,18 @@
 // Challenge Response Authentication Mechanism (SCRAM) described in RFC-5802
 // and RFC-7677.
 //
-// Usage
+// # Usage
 //
 // The scram package provides variables, `SHA1`, `SHA256`, and `SHA512`, that
 // are used to construct Client or Server objects.
 //
-//     clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
-//     clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
-//     clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
+//	clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
+//	clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
+//	clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
 //
-//     serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
-//     serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
-//     serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
+//	serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
+//	serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
+//	serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
 //
 // These objects are used to construct ClientConversation or
 // ServerConversation objects that are used to carry out authentication.

--- a/vendor/github.com/xdg-go/scram/doc.go
+++ b/vendor/github.com/xdg-go/scram/doc.go
@@ -8,18 +8,18 @@
 // Challenge Response Authentication Mechanism (SCRAM) described in RFC-5802
 // and RFC-7677.
 //
-// # Usage
+// Usage
 //
 // The scram package provides variables, `SHA1`, `SHA256`, and `SHA512`, that
 // are used to construct Client or Server objects.
 //
-//	clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
-//	clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
-//	clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
+//     clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
+//     clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
+//     clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
 //
-//	serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
-//	serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
-//	serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
+//     serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
+//     serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
+//     serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
 //
 // These objects are used to construct ClientConversation or
 // ServerConversation objects that are used to carry out authentication.

--- a/vendor/github.com/youmark/pkcs8/kdf_pbkdf2.go
+++ b/vendor/github.com/youmark/pkcs8/kdf_pbkdf2.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	oidPKCS5PBKDF2    = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
-	oidHMACWithSHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 7}
-	oidHMACWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
+	oidPKCS5PBKDF2        = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
+	oidHMACWithSHA1       = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 7}
+	oidHMACWithSHA256     = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
 )
 
 func init() {

--- a/vendor/github.com/youmark/pkcs8/kdf_pbkdf2.go
+++ b/vendor/github.com/youmark/pkcs8/kdf_pbkdf2.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	oidPKCS5PBKDF2        = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
-	oidHMACWithSHA1       = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 7}
-	oidHMACWithSHA256     = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
+	oidPKCS5PBKDF2    = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
+	oidHMACWithSHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 7}
+	oidHMACWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
 )
 
 func init() {


### PR DESCRIPTION
# Pull Request: Standardize Agent Harness, Security Guidelines, and Credential Safety

## Description
This Pull Request restructures the repository's onboarding documentation, establishes a comprehensive AI agent document harness, cleans up root-level developer files, and sanitizes environment credential defaults.

## Key Changes

### 1. Agent Documentation Harness (docs/)
Created a dedicated documentation directory to organize guidelines for developers and AI agents:
- **docs/README.md**: Main index serving as the entry point for the harness.
- **docs/agent_personas.md**: Consolidated configuration and expectations for specialized agent roles (Software Engineering and DevOps).
- **docs/architecture.md**: Explains core packages, data pathways, and includes a Mermaid diagram of the ingestion pipeline.
- **docs/pii_handling.md**: Outlines log scrubbing practices, safety boundaries, and the importance of using synthetic data rather than production files.
- **docs/development.md**: Standardizes prerequisites, build tools, quality checks, and local troubleshooting.

### 2. File and Workspace Cleanup
- Removed the obsolete root files `agent.md` and `aget.devops.md` to keep the root directory tidy and ensure `docs/` is the single source of truth.
- Formatted all project documentation and layout blocks to omit emojis.

### 3. Setup and Configuration Improvements
- **CLAUDE.md**: Created and configured a new helper guide mapping quality checks, linting, formatting, testing, and synthetic data generation commands. Connected it directly to the new `docs/` harness.
- **README.md**: Upgraded to a clean, modern layout. Updated prerequisite versioning (Go 1.26), highlighted the new documentation folders, added a PII warning notice, and scrubbed hardcoded credentials.

### 4. Credential Sanitization
- Removed hardcoded values (`babylon`/`babylonpass`) from standard configurations and replaced them with placeholders:
  - **makefile**: Replaced Mongo credentials with `<MONGO_USER>` and `<MONGO_PASSWORD>`.
  - **README.md** & **docs/development.md**: Replaced local setup credentials with `<MONGO_USER>` and `<MONGO_PASSWORD>`.

---

## Verification Run

Ran project validation to verify all changes:
- `make check-quality` (Linting, Formatting, and `go vet` completed successfully with 0 issues).
- `make unit-test` (All unit tests passed).
